### PR TITLE
Edited arch part to force armv7l for the pbp on default debian

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1630,7 +1630,7 @@ nvm_get_arch() {
   elif [ "_${NVM_OS}" = "_aix" ]; then
     HOST_ARCH=ppc64
   else
-    HOST_ARCH="$(command uname -m)"
+    HOST_ARCH="armv7l"
   fi
 
   local NVM_ARCH


### PR DESCRIPTION
It forces armv7l architecture for devices with arm64 kernel but arm32 userland.